### PR TITLE
Added const correctness in initialization

### DIFF
--- a/include/BufferPacker.h
+++ b/include/BufferPacker.h
@@ -62,7 +62,7 @@ public:
      * is larger than the size of the internal buffer. Otherwise, the BufferPacker is put into UNPACK mode and his the
      * data in the src buffer copied to the internal buffer.
      */
-    template <size_t SRC_SIZE> explicit BufferPacker(uint8_t (&src)[SRC_SIZE]) : m_DataSize(SRC_SIZE), m_Offset(0)
+    template <size_t SRC_SIZE> explicit BufferPacker(const uint8_t (&src)[SRC_SIZE]) : m_DataSize(SRC_SIZE), m_Offset(0)
     {
         if (SRC_SIZE > SIZE)
         {


### PR DESCRIPTION
This is needed in order to create a unpacker from a const CAN_message_t& msg.buf